### PR TITLE
fix(entities): add missing youtube channels

### DIFF
--- a/entities/barbarian assault.json
+++ b/entities/barbarian assault.json
@@ -5,7 +5,7 @@
   "tags": ["minigame","defender","healer"],
   "recommendedGuideVideoId": "Q_auOReO_2Y",
   "source": {
-    "name": "Barbarian Assault for Beginners (OSRS)",
+    "name": "Theoatrix OSRS - Barbarian Assault for Beginners (OSRS)",
     "link": "https://www.youtube.com/watch?v=Q_auOReO_2Y"
   },
   "tiles": [

--- a/entities/commander zilyana (energy-efficient).json
+++ b/entities/commander zilyana (energy-efficient).json
@@ -6,7 +6,7 @@
   "wiki": "https://oldschool.runescape.wiki/w/Commander_Zilyana",
   "tags": ["boss", "godwars", "gwd"],
   "source": {
-    "name": "GeChallengeM - Solo Saradomin GWD for Crossbows/Tbow (Energy-efficient)",
+    "name": "GeChallengeM - Solo Saradomin GWD for Shadow/Tbow/Crossbows (Energy-efficient)",
     "link": "https://www.youtube.com/watch?v=WUa4T1lRNKo"
   },
   "recommendedGuideVideoId": "WUa4T1lRNKo",

--- a/entities/doom (double park).json
+++ b/entities/doom (double park).json
@@ -6,7 +6,7 @@
   "tags": ["boss", "mokhaiotl", "doom of mokhaiotl", "delve"],
   "recommendedGuideVideoId": "ULu5XC2weus",
   "source": {
-    "name": "Doom Boss Lvl 8+ In-Depth Guide (Deep Delve 10+ Guide)",
+    "name": "Real Mango - Doom Boss Lvl 8+ In-Depth Guide (Deep Delve 10+ Guide)",
     "link": "https://www.youtube.com/watch?v=ULu5XC2weus"
   },
   "tiles": [

--- a/entities/doom (sidewalk).json
+++ b/entities/doom (sidewalk).json
@@ -6,7 +6,7 @@
   "tags": ["boss", "mokhaiotl", "doom of mokhaiotl", "delve"],
   "recommendedGuideVideoId": "MCnp9qSyjAA",
   "source": {
-    "name": "Sidewalk tech - Consistent Doom of Mokhaiotl depth 6+ strategy",
+    "name": "Muffyn - Sidewalk tech - Consistent Doom of Mokhaiotl depth 6+ strategy",
     "link": "https://pastebin.com/LTWPsv6d"
   },
   "tiles": [

--- a/entities/drift net fishing.json
+++ b/entities/drift net fishing.json
@@ -5,7 +5,7 @@
   "tags": ["Fishing", "Skilling"],
   "recommendedGuideVideoId": "YOA6p7hjmF8",
   "source": {
-    "name": "OSRS Drift Net Fishing Guide (Efficient Method)",
+    "name": "King Karuulm - OSRS Drift Net Fishing Guide (Efficient Method)",
     "link": "https://www.youtube.com/watch?v=YOA6p7hjmF8"
   },
   "tiles": [

--- a/entities/general graardor (6-0).json
+++ b/entities/general graardor (6-0).json
@@ -7,7 +7,7 @@
   "tags": ["boss", "godwars", "gwd", "bandos"],
   "recommendedGuideVideoId": "oIWnXBqebTU",
   "source": {
-    "name": "NoBankWicked - Bandos 6:0 Method (ranged)",
+    "name": "Greg Post - Bandos 6:0 Method (ranged)",
     "link": "https://www.youtube.com/watch?v=oIWnXBqebTU",
     "modified": "Added the label \"start\" to the starting tile"
   },

--- a/entities/general graardor (7-0 Bowfa).json
+++ b/entities/general graardor (7-0 Bowfa).json
@@ -7,7 +7,7 @@
   "tags": ["boss", "godwars", "gwd", "bandos"],
   "recommendedGuideVideoId": "H_6OZhaNd64",
   "source": {
-    "name": "MrHaroto -  Quick 7:0 Bandos Guide",
+    "name": "MrHaroto - Quick 7:0 Bandos Guide",
     "link": "https://www.youtube.com/watch?v=H_6OZhaNd64",
     "modified": "Different colours and labels as well as a cannon tile"
   },


### PR DESCRIPTION
Add youtube channels for sources in:
- barbarian assault
- doom double park
- doom sidewalk
- drift net fishing
- general graardor 7-0 bowfa

Update channel title for Graardor 6:0
Update video name for Zilyana energy efficient